### PR TITLE
Modernize install CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -80,7 +80,7 @@ async function install ({ force = false } = {}) {
 
   const DEST = PATH.join(
     process.env.HOME,
-    'Library/Application Support/Glyphs/Info'
+    'Library/Application Support/Glyphs 3/Info'
   )
 
   let destExists = false

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,7 @@
 
 // core Node imports
 import fs from 'node:fs/promises'
-import PATH from 'node:path'
+import nodePath from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs, styleText } from 'node:util'
 
@@ -71,14 +71,14 @@ async function install ({ force = false } = {}) {
   const FILES = [
     '../dist/GlyphData-smufl.xml',
     '../dist/Groups-smufl.plist'
-  ].map(path => PATH.join(__dirname, path))
+  ].map(path => nodePath.join(__dirname, path))
 
   if (!process.env.HOME) {
     cancel('Could not determine home directory. Please open an issue: https://github.com/delucis/smufl-glyphs-info')
     process.exit(1)
   }
 
-  const DEST = PATH.join(
+  const DEST = nodePath.join(
     process.env.HOME,
     'Library/Application Support/Glyphs 3/Info'
   )
@@ -111,8 +111,8 @@ async function copyResources (files = [], dest = '', overwrite = true) {
   const flag = overwrite ? undefined : fs.constants.COPYFILE_EXCL
 
   await Promise.all(files.map(async file => {
-    let fname = PATH.basename(file)
-    return fs.copyFile(file, PATH.join(dest, fname), flag)
+    let fname = nodePath.basename(file)
+    return fs.copyFile(file, nodePath.join(dest, fname), flag)
       .then(() => log.success(`Copied ${fname} to ${dest}`))
   }))
 }
@@ -132,8 +132,8 @@ async function copySafely (files = [], dest = '') {
     /** @type { { file: string, xml?: string } } */
     let data = { file }
     let exists = true
-    let fname = PATH.basename(file)
-    let xml = await fs.readFile(PATH.join(dest, fname), 'utf8')
+    let fname = nodePath.basename(file)
+    let xml = await fs.readFile(nodePath.join(dest, fname), 'utf8')
       .catch((err) => {
         if (err.code !== 'ENOENT') throw err
         exists = false
@@ -172,12 +172,12 @@ async function resolveConflicts (conflicts, dest) {
   }))
 
   skippable.forEach(conflict => {
-    let fname = PATH.basename(conflict.file)
+    let fname = nodePath.basename(conflict.file)
     log.info(`Skipped copying ${fname} as it is already installed`)
   })
 
   let prompts = clashing.map(conflict => {
-    let fname = PATH.basename(conflict.file)
+    let fname = nodePath.basename(conflict.file)
     return /** @type const */ ([
       conflict.file,
       () => confirm({
@@ -192,7 +192,7 @@ async function resolveConflicts (conflicts, dest) {
     if (answers[answer]) {
       await copyResources([ answer ], dest)
     } else {
-      let fname = PATH.basename(answer)
+      let fname = nodePath.basename(answer)
       log.warn(`Did not copy ${fname}. It was not installed.`)
     }
   }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 // core Node imports
-import fs from 'node:fs/promises'
-import nodePath from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { parseArgs, styleText } from 'node:util'
+import fs from 'node:fs/promises';
+import nodePath from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs, styleText } from 'node:util';
 
 // required libraries
 import { cancel, confirm, group, intro, isCancel, log } from '@clack/prompts';
@@ -47,16 +47,16 @@ options for how to handle the conflict.
 /**
  * Show an initial prompt to confirm installation.
  */
-async function startPrompt () {
-  intro('Welcome to the SMuFL Glyphs Info Installer')
-  let shouldInstall = await confirm({
-    message: 'This script will set up SMuFL support in Glyphs. Do you want to continue?',
-  })
-  if (isCancel(shouldInstall) || !shouldInstall) {
-    cancel('Installation cancelled.')
-  } else {
-    install()
-  }
+async function startPrompt() {
+	intro('Welcome to the SMuFL Glyphs Info Installer');
+	let shouldInstall = await confirm({
+		message: 'This script will set up SMuFL support in Glyphs. Do you want to continue?',
+	});
+	if (isCancel(shouldInstall) || !shouldInstall) {
+		cancel('Installation cancelled.');
+	} else {
+		install();
+	}
 }
 
 /**
@@ -64,41 +64,40 @@ async function startPrompt () {
  * @param  {Object}  [opts] Installation options
  * @param  {Boolean} [opts.force=false] Force the installation without checking for conflicts or requesting user input.
  */
-async function install ({ force = false } = {}) {
-  if (force) log.warn('Installing with --force flag. Any checks for conflicts will be skipped.')
+async function install({ force = false } = {}) {
+	if (force) log.warn('Installing with --force flag. Any checks for conflicts will be skipped.');
 
-  const __dirname = fileURLToPath(new URL('.', import.meta.url));
-  const FILES = [
-    '../dist/GlyphData-smufl.xml',
-    '../dist/Groups-smufl.plist'
-  ].map(path => nodePath.join(__dirname, path))
+	const __dirname = fileURLToPath(new URL('.', import.meta.url));
+	const FILES = ['../dist/GlyphData-smufl.xml', '../dist/Groups-smufl.plist'].map((path) =>
+		nodePath.join(__dirname, path)
+	);
 
-  if (!process.env.HOME) {
-    cancel('Could not determine home directory. Please open an issue: https://github.com/delucis/smufl-glyphs-info')
-    process.exit(1)
-  }
+	if (!process.env.HOME) {
+		cancel(
+			'Could not determine home directory. Please open an issue: https://github.com/delucis/smufl-glyphs-info'
+		);
+		process.exit(1);
+	}
 
-  const DEST = nodePath.join(
-    process.env.HOME,
-    'Library/Application Support/Glyphs 3/Info'
-  )
+	const DEST = nodePath.join(process.env.HOME, 'Library/Application Support/Glyphs 3/Info');
 
-  let destExists = false
+	let destExists = false;
 
-  await fs.mkdir(DEST)
-    .then(() => {
-      log.info(`Created ${DEST}`)
-    })
-    .catch((err) => {
-      if (err.code !== 'EEXIST') throw err
-      destExists = true
-    })
+	await fs
+		.mkdir(DEST)
+		.then(() => {
+			log.info(`Created ${DEST}`);
+		})
+		.catch((err) => {
+			if (err.code !== 'EEXIST') throw err;
+			destExists = true;
+		});
 
-  if (force || !destExists) {
-    await copyResources(FILES, DEST)
-  } else {
-    await copySafely(FILES, DEST)
-  }
+	if (force || !destExists) {
+		await copyResources(FILES, DEST);
+	} else {
+		await copySafely(FILES, DEST);
+	}
 }
 
 /**
@@ -107,14 +106,17 @@ async function install ({ force = false } = {}) {
  * @param  {String}   [dest='']        The destination directory to copy to.
  * @param  {Boolean}  [overwrite=true] Should existing files be overwritten?
  */
-async function copyResources (files = [], dest = '', overwrite = true) {
-  const flag = overwrite ? undefined : fs.constants.COPYFILE_EXCL
+async function copyResources(files = [], dest = '', overwrite = true) {
+	const flag = overwrite ? undefined : fs.constants.COPYFILE_EXCL;
 
-  await Promise.all(files.map(async file => {
-    let fname = nodePath.basename(file)
-    return fs.copyFile(file, nodePath.join(dest, fname), flag)
-      .then(() => log.success(`Copied ${fname} to ${dest}`))
-  }))
+	await Promise.all(
+		files.map(async (file) => {
+			let fname = nodePath.basename(file);
+			return fs
+				.copyFile(file, nodePath.join(dest, fname), flag)
+				.then(() => log.success(`Copied ${fname} to ${dest}`));
+		})
+	);
 }
 
 /**
@@ -122,33 +124,34 @@ async function copyResources (files = [], dest = '', overwrite = true) {
  * @param  {String[]} [files=[]] The paths for the files to copy.
  * @param  {String}   [dest='']  The destination directory to copy to.
  */
-async function copySafely (files = [], dest = '') {
-  /** @type {Array<{ file: string, xml?: string }>} */
-  let conflicts = []
-  /** @type {string[]} */
-  let safeFiles = []
+async function copySafely(files = [], dest = '') {
+	/** @type {Array<{ file: string, xml?: string }>} */
+	let conflicts = [];
+	/** @type {string[]} */
+	let safeFiles = [];
 
-  await Promise.all(files.map(async file => {
-    /** @type { { file: string, xml?: string } } */
-    let data = { file }
-    let exists = true
-    let fname = nodePath.basename(file)
-    let xml = await fs.readFile(nodePath.join(dest, fname), 'utf8')
-      .catch((err) => {
-        if (err.code !== 'ENOENT') throw err
-        exists = false
-      })
-    if (xml) data.xml = xml
-    if (exists) {
-      conflicts.push(data)
-    } else {
-      safeFiles.push(file)
-    }
-  }))
+	await Promise.all(
+		files.map(async (file) => {
+			/** @type { { file: string, xml?: string } } */
+			let data = { file };
+			let exists = true;
+			let fname = nodePath.basename(file);
+			let xml = await fs.readFile(nodePath.join(dest, fname), 'utf8').catch((err) => {
+				if (err.code !== 'ENOENT') throw err;
+				exists = false;
+			});
+			if (xml) data.xml = xml;
+			if (exists) {
+				conflicts.push(data);
+			} else {
+				safeFiles.push(file);
+			}
+		})
+	);
 
-  await copyResources(safeFiles, dest, false)
+	await copyResources(safeFiles, dest, false);
 
-  await resolveConflicts(conflicts, dest)
+	await resolveConflicts(conflicts, dest);
 }
 
 /**
@@ -156,46 +159,49 @@ async function copySafely (files = [], dest = '') {
  * @param {{ file: string, xml?: string }[]} conflicts Array of objects describing conflicting files.
  * @param {string} dest The destination directory to copy to.
  */
-async function resolveConflicts (conflicts, dest) {
-  /** @type {Array<{ file: string, xml?: string }>} */
-  let skippable = []
-  /** @type {Array<{ file: string, xml?: string }>} */
-  let clashing = []
+async function resolveConflicts(conflicts, dest) {
+	/** @type {Array<{ file: string, xml?: string }>} */
+	let skippable = [];
+	/** @type {Array<{ file: string, xml?: string }>} */
+	let clashing = [];
 
-  await Promise.all(conflicts.map(async conflict => {
-    let xml = await fs.readFile(conflict.file, 'utf8')
-    if (xml === conflict.xml) {
-      skippable.push(conflict)
-    } else {
-      clashing.push(conflict)
-    }
-  }))
+	await Promise.all(
+		conflicts.map(async (conflict) => {
+			let xml = await fs.readFile(conflict.file, 'utf8');
+			if (xml === conflict.xml) {
+				skippable.push(conflict);
+			} else {
+				clashing.push(conflict);
+			}
+		})
+	);
 
-  skippable.forEach(conflict => {
-    let fname = nodePath.basename(conflict.file)
-    log.info(`Skipped copying ${fname} as it is already installed`)
-  })
+	skippable.forEach((conflict) => {
+		let fname = nodePath.basename(conflict.file);
+		log.info(`Skipped copying ${fname} as it is already installed`);
+	});
 
-  let prompts = clashing.map(conflict => {
-    let fname = nodePath.basename(conflict.file)
-    return /** @type const */ ([
-      conflict.file,
-      () => confirm({
-        message: `A different ${fname} was found. Are you sure you want to overwrite it?`
-      })
-    ])
-  })
+	let prompts = clashing.map((conflict) => {
+		let fname = nodePath.basename(conflict.file);
+		return /** @type const */ ([
+			conflict.file,
+			() =>
+				confirm({
+					message: `A different ${fname} was found. Are you sure you want to overwrite it?`,
+				}),
+		]);
+	});
 
-  let answers = await group(Object.fromEntries(prompts))
+	let answers = await group(Object.fromEntries(prompts));
 
-  for (var answer in answers) {
-    if (answers[answer]) {
-      await copyResources([ answer ], dest)
-    } else {
-      let fname = nodePath.basename(answer)
-      log.warn(`Did not copy ${fname}. It was not installed.`)
-    }
-  }
+	for (var answer in answers) {
+		if (answers[answer]) {
+			await copyResources([answer], dest);
+		} else {
+			let fname = nodePath.basename(answer);
+			log.warn(`Did not copy ${fname}. It was not installed.`);
+		}
+	}
 }
 
 /*
@@ -213,23 +219,27 @@ async function resolveConflicts (conflicts, dest) {
 */
 
 if (process.platform !== 'darwin') {
-  cancel('This script is designed for use on macOS only.\n' +
-    'Running on macOS and seeing this error?\n' +
-    `Please open an issue at ${styleText(['underline'], 'https://github.com/delucis/smufl-glyphs-info')}`
-  )
-  process.exit(1)
+	const repoLink = styleText(['underline'], 'https://github.com/delucis/smufl-glyphs-info');
+	cancel(
+		'This script is designed for use on macOS only.\n' +
+			'Running on macOS and seeing this error?\n' +
+			`Please open an issue at ${repoLink}`
+	);
+	process.exit(1);
 }
 
-const args = parseArgs({options: {
-  force: { type: 'boolean', short: 'f', default: false },
-  help: { type: 'boolean', short: 'h', default: false },
-}});
+const args = parseArgs({
+	options: {
+		force: { type: 'boolean', short: 'f', default: false },
+		help: { type: 'boolean', short: 'h', default: false },
+	},
+});
 
 if (args.values.help) {
-  console.log(helpMessage);
-  process.exit(0);
+	console.log(helpMessage);
+	process.exit(0);
 } else if (args.values.force) {
-  install({ force: true });
+	install({ force: true });
 } else {
-  startPrompt();
+	startPrompt();
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // core Node imports
-import { mkdir, copyFile, readFile, constants } from 'node:fs/promises'
+import fs from 'node:fs/promises'
 import PATH from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs, styleText } from 'node:util'
@@ -85,7 +85,7 @@ async function install ({ force = false } = {}) {
 
   let destExists = false
 
-  await mkdir(DEST)
+  await fs.mkdir(DEST)
     .then(() => {
       log.info(`Created ${DEST}`)
     })
@@ -108,11 +108,11 @@ async function install ({ force = false } = {}) {
  * @param  {Boolean}  [overwrite=true] Should existing files be overwritten?
  */
 async function copyResources (files = [], dest = '', overwrite = true) {
-  const flag = overwrite ? undefined : constants.COPYFILE_EXCL
+  const flag = overwrite ? undefined : fs.constants.COPYFILE_EXCL
 
   await Promise.all(files.map(async file => {
     let fname = PATH.basename(file)
-    return copyFile(file, PATH.join(dest, fname), flag)
+    return fs.copyFile(file, PATH.join(dest, fname), flag)
       .then(() => log.success(`Copied ${fname} to ${dest}`))
   }))
 }
@@ -133,7 +133,7 @@ async function copySafely (files = [], dest = '') {
     let data = { file }
     let exists = true
     let fname = PATH.basename(file)
-    let xml = await readFile(PATH.join(dest, fname), 'utf8')
+    let xml = await fs.readFile(PATH.join(dest, fname), 'utf8')
       .catch((err) => {
         if (err.code !== 'ENOENT') throw err
         exists = false
@@ -163,7 +163,7 @@ async function resolveConflicts (conflicts, dest) {
   let clashing = []
 
   await Promise.all(conflicts.map(async conflict => {
-    let xml = await readFile(conflict.file, 'utf8')
+    let xml = await fs.readFile(conflict.file, 'utf8')
     if (xml === conflict.xml) {
       skippable.push(conflict)
     } else {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,7 +24,7 @@ import { cancel, confirm, intro, isCancel, log } from '@clack/prompts';
 */
 
 const helpMessage = `
-Usage: smufl-glyphs [options]
+Usage: ${styleText(['bold'], 'npx smufl-glyphs-info')} ${styleText(['dim'], '[options]')}
 
 Options:
   -f, --force      install SMuFl support without user input, overwriting any existing files
@@ -50,7 +50,7 @@ options for how to handle the conflict.
 async function startPrompt() {
 	intro('Welcome to the SMuFL Glyphs Info Installer');
 	let shouldInstall = await confirm({
-		message: 'This script will set up SMuFL support in Glyphs. Do you want to continue?',
+		message: 'This script will set up SMuFL support in Glyphs 3. Do you want to continue?',
 		initialValue: false,
 	});
 	if (isCancel(shouldInstall) || !shouldInstall) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,10 +4,11 @@
 import fs from 'node:fs/promises';
 import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseArgs, styleText } from 'node:util';
+import { parseArgs } from 'node:util';
 
 // required libraries
 import { cancel, confirm, intro, isCancel, log } from '@clack/prompts';
+import fmt from 'femtocolors';
 
 /*
 ███████ ██    ██ ███    ██  ██████ ████████ ██  ██████  ███    ██
@@ -23,14 +24,8 @@ import { cancel, confirm, intro, isCancel, log } from '@clack/prompts';
 ██████  ███████ ██      ██ ██   ████ ██    ██    ██  ██████  ██   ████ ███████
 */
 
-/**
- * Style text in bold for terminal output.
- * @param {string} string
- */
-const bold = (string) => styleText(['bold'], string);
-
 const helpMessage = `
-Usage: ${bold('npx smufl-glyphs-info')} ${styleText(['dim'], '[options]')}
+Usage: ${fmt.bold('npx smufl-glyphs-info')} ${fmt.dim('[options]')}
 
 Options:
   -f, --force      install SMuFl support without user input, overwriting any existing files
@@ -185,20 +180,20 @@ async function resolveConflicts(conflicts, dest) {
 
 	for (const { file } of skippable) {
 		let fname = nodePath.basename(file);
-		log.info(`Skipped copying ${bold(fname)} as it is already installed`);
+		log.info(`Skipped copying ${fmt.bold(fname)} as it is already installed`);
 	}
 
 	for (const { file } of clashing) {
 		let fname = nodePath.basename(file);
 		const shouldOverwrite = await confirm({
-			message: `A different ${bold(fname)} was found. Do you want to overwrite it?`,
+			message: `A different ${fmt.bold(fname)} was found. Do you want to overwrite it?`,
 			initialValue: false,
 		});
 		if (isCancel(shouldOverwrite)) {
 			cancel('Installation cancelled.');
 			process.exit(0);
 		} else if (!shouldOverwrite) {
-			log.warn(`Did not copy ${bold(fname)}. It was not installed.`);
+			log.warn(`Did not copy ${fmt.bold(fname)}. It was not installed.`);
 		} else {
 			await copyResources([file], dest);
 		}
@@ -220,7 +215,7 @@ async function resolveConflicts(conflicts, dest) {
 */
 
 if (process.platform !== 'darwin') {
-	const repoLink = styleText(['underline'], 'https://github.com/delucis/smufl-glyphs-info');
+	const repoLink = fmt.underline('https://github.com/delucis/smufl-glyphs-info');
 	cancel(
 		'This script is designed for use on macOS only.\n' +
 			'Running on macOS and seeing this error?\n' +

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -23,8 +23,14 @@ import { cancel, confirm, intro, isCancel, log } from '@clack/prompts';
 ██████  ███████ ██      ██ ██   ████ ██    ██    ██  ██████  ██   ████ ███████
 */
 
+/**
+ * Style text in bold for terminal output.
+ * @param {string} string
+ */
+const bold = (string) => styleText(['bold'], string);
+
 const helpMessage = `
-Usage: ${styleText(['bold'], 'npx smufl-glyphs-info')} ${styleText(['dim'], '[options]')}
+Usage: ${bold('npx smufl-glyphs-info')} ${styleText(['dim'], '[options]')}
 
 Options:
   -f, --force      install SMuFl support without user input, overwriting any existing files
@@ -177,24 +183,24 @@ async function resolveConflicts(conflicts, dest) {
 		})
 	);
 
-	skippable.forEach((conflict) => {
-		let fname = nodePath.basename(conflict.file);
-		log.info(`Skipped copying ${fname} as it is already installed`);
-	});
+	for (const { file } of skippable) {
+		let fname = nodePath.basename(file);
+		log.info(`Skipped copying ${bold(fname)} as it is already installed`);
+	}
 
-	for (const conflict of clashing) {
-		let fname = nodePath.basename(conflict.file);
+	for (const { file } of clashing) {
+		let fname = nodePath.basename(file);
 		const shouldOverwrite = await confirm({
-			message: `A different ${styleText(['bold'], fname)} was found. Do you want to overwrite it?`,
+			message: `A different ${bold(fname)} was found. Do you want to overwrite it?`,
 			initialValue: false,
 		});
 		if (isCancel(shouldOverwrite)) {
 			cancel('Installation cancelled.');
 			process.exit(0);
 		} else if (!shouldOverwrite) {
-			log.warn(`Did not copy ${fname}. It was not installed.`);
+			log.warn(`Did not copy ${bold(fname)}. It was not installed.`);
 		} else {
-			await copyResources([conflict.file], dest);
+			await copyResources([file], dest);
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "darwin"
       ],
       "dependencies": {
-        "@clack/prompts": "^0.11.0"
+        "@clack/prompts": "^0.11.0",
+        "femtocolors": "^0.1.2"
       },
       "bin": {
         "smufl-glyphs": "bin/cli.js"
@@ -76,6 +77,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/femtocolors": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/femtocolors/-/femtocolors-0.1.2.tgz",
+      "integrity": "sha512-7CalG9ZvozpPx5Keuxg89A8lLCyNu/NPW6635RhHbYTR3qAVT8ClfdLWkjIEr8YeZw//epxbjI/pGK9MC1aerg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
       "devDependencies": {
         "plist": "^3.1.0",
         "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@clack/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "darwin"
       ],
       "dependencies": {
-        "commander": "^2.15.0",
-        "prompts": "^0.1.8"
+        "@clack/prompts": "^0.11.0"
       },
       "bin": {
         "smufl-glyphs": "bin/cli.js"
@@ -21,6 +20,27 @@
       "devDependencies": {
         "plist": "^3.1.0",
         "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
+      "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.5.0",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -54,16 +74,11 @@
       ],
       "license": "MIT"
     },
-    "node_modules/clorox": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clorox/-/clorox-1.0.3.tgz",
-      "integrity": "sha512-w3gKAUKMJYmmaJyc+p+iDrDtLvsFasrx/y6/zWo2U1TZfsz3y4Vl4T9PHCZrOwk1eMTOSRI6xHdpDR4PhTdy8Q==",
-      "deprecated": "Clorox is now Turbocolor!! - Please upgrade <3 'npm i turbocolor'"
-    },
-    "node_modules/commander": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-      "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/plist": {
       "version": "3.1.0",
@@ -80,22 +95,11 @@
         "node": ">=10.4.0"
       }
     },
-    "node_modules/prompts": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.8.tgz",
-      "integrity": "sha512-IAV6uUb0fj4BgGyuWbjx0qZuJuUiIUhpzPq6yZyyEVmY9SHMkA+qIR7PVY2zl2nOJNVjqO8UfYgwUILU39vtQQ==",
-      "dependencies": {
-        "clorox": "^1.0.1",
-        "sisteransi": "^0.1.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/sisteransi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.0.tgz",
-      "integrity": "sha512-kHXcIr0Z9FM6d7pwFDDIMQKGndIEtIF1oBSMXWtItpx4mrH1jhANVNT35GVekBekXl6J+5i7lJMIGq3Gm7pIdA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "darwin"
       ],
       "dependencies": {
-        "clorox": "^1.0.3",
         "commander": "^2.15.0",
         "prompts": "^0.1.8"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "xmlbuilder": "^15.1.1"
   },
   "dependencies": {
-    "commander": "^2.15.0",
-    "prompts": "^0.1.8"
+    "@clack/prompts": "^0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "xmlbuilder": "^15.1.1"
   },
   "dependencies": {
-    "clorox": "^1.0.3",
     "commander": "^2.15.0",
     "prompts": "^0.1.8"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "xmlbuilder": "^15.1.1"
   },
   "dependencies": {
-    "@clack/prompts": "^0.11.0"
+    "@clack/prompts": "^0.11.0",
+    "femtocolors": "^0.1.2"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
The install CLI was written 8 years ago and it shows.

This PR replaces the `clorox` package with Node’s built-in `styleText` utility, the `commander` package with Node’s built-in `parseArgs` utility, and the `prompts` package with `@clack/prompts` which is a modern and lightweight alternative.

It also refactors from Common JS to an ES module, and updates the path the CLI copies files to for compatibility with Glyphs 3.